### PR TITLE
Remove www. from url if exist VersionControlFactory.php

### DIFF
--- a/dokum/app/libs/VersionControl/VersionControlFactory.php
+++ b/dokum/app/libs/VersionControl/VersionControlFactory.php
@@ -15,8 +15,8 @@ class VersionControlFactory
      */
     public static function createFromUrl(string $url): VersionControlInterface
     {
-        $host = strtolower(parse_url($url, PHP_URL_HOST));
-
+        $host = str_replace('www.', '', strtolower(parse_url($url, PHP_URL_HOST)));
+        
         return match($host) {
             'github.com' => new Adapters\Github(),
             'gitlab.com' => new Adapters\Gitlab(),


### PR DESCRIPTION
Still remove from domains and subdomains ending in 'www.', but for now it isn't the case